### PR TITLE
Fix for XDS ErrorInfo translation

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/ebxml30/EbXMLExtrinsicObject30.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/ebxml30/EbXMLExtrinsicObject30.java
@@ -53,6 +53,6 @@ public class EbXMLExtrinsicObject30 extends EbXMLRegistryObject30<ExtrinsicObjec
 
     @Override
     public void setStatus(AvailabilityStatus status) {
-        getInternal().setStatus(AvailabilityStatus.toOpcode(status));
+        getInternal().setStatus(AvailabilityStatus.toQueryOpcode(status));
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/hl7/PatientInfoTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/hl7/PatientInfoTransformer.java
@@ -97,9 +97,12 @@ public class PatientInfoTransformer {
         for (Map.Entry<Integer, PIDTransformer> entry : pidTransformers.entrySet()) {
             String hl7Data = entry.getValue().toHL7(patientInfo);
             if (hl7Data != null && !hl7Data.isEmpty()) {
-                String pidNoStr = PID_PREFIX + entry.getKey();
-                String pidStr = HL7.render(HL7Delimiter.FIELD, pidNoStr, hl7Data);
-                hl7Strings.add(pidStr);
+                List<String> repetitions = HL7.parse(HL7Delimiter.REPETITION, hl7Data);
+                for ( String repetition : repetitions) {
+                    String pidNoStr = PID_PREFIX + entry.getKey();
+                    String pidStr = HL7.render(HL7Delimiter.FIELD, pidNoStr, repetition);
+                    hl7Strings.add(pidStr);
+                }
             }
         }
         

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/ValidationMessage.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/ValidationMessage.java
@@ -29,7 +29,7 @@ public enum ValidationMessage {
     INVALID_TITLE_ENCODING("Invalid encoding for document entry title: %1s"),
     TITLE_TOO_LONG("Document entry title too long: %1s"),
     UNIQUE_ID_MISSING("Document entries, folders and submission sets are required to define a unique ID"),
-    UNIQUE_ID_TOO_LONG("Unique IDs must not be longer than 64 characters"),
+    UNIQUE_ID_TOO_LONG("Unique IDs must not be longer than 128 characters"),
     UNIQUE_ID_NOT_UNIQUE("Duplicate ID found"),
     UUID_NOT_UNIQUE("Duplicate UUID found"),
     DOC_ENTRY_PATIENT_ID_WRONG("Document entry and submission set must define the same patient ID", ErrorCode.PATIENT_ID_DOES_NOT_MATCH),

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/ObjectContainerValidator.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/ObjectContainerValidator.java
@@ -192,7 +192,7 @@ public class ObjectContainerValidator implements Validator<EbXMLObjectContainer,
         for (EbXMLRegistryObject obj : objects) {
             String uniqueId = obj.getExternalIdentifierValue(scheme);
             metaDataAssert(uniqueId != null, UNIQUE_ID_MISSING);
-            metaDataAssert(uniqueId.length() <= 64, UNIQUE_ID_TOO_LONG);
+            metaDataAssert(uniqueId.length() <= 128, UNIQUE_ID_TOO_LONG);
 
             metaDataAssert(!uniqueIds.contains(uniqueId), UNIQUE_ID_NOT_UNIQUE);
             uniqueIds.add(uniqueId);

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/ebxml/DocumentEntryTransformerTestBase.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/ebxml/DocumentEntryTransformerTestBase.java
@@ -159,7 +159,8 @@ public abstract class DocumentEntryTransformerTestBase implements FactoryCreator
         assertSlot(SLOT_NAME_LEGAL_AUTHENTICATOR, slots, "id 2^familyName 2^givenName 2^prefix 2^second 2^suffix 2^^^namespace 2&uni 2&uniType 2");
         assertSlot(SLOT_NAME_REPOSITORY_UNIQUE_ID, slots, "repo1");
         assertSlot(SLOT_NAME_SOURCE_PATIENT_INFO, slots, 
-                "PID-3|id 5^^^namespace 5&uni 5&uniType 5~id 6^^^namespace 6&uni 6&uniType 6",
+                "PID-3|id 5^^^namespace 5&uni 5&uniType 5",
+                "PID-3|id 6^^^namespace 6&uni 6&uniType 6",
                 "PID-5|familyName 3^givenName 3^prefix 3^second 3^suffix 3",
                 "PID-7|dateOfBirth",
                 "PID-8|F",

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/hl7/PatientInfoTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/hl7/PatientInfoTransformerTest.java
@@ -71,6 +71,39 @@ public class PatientInfoTransformerTest {
     }
     
     @Test
+    public void testToHL7MultiId() {
+        PatientInfo patientInfo = new PatientInfo();
+
+        Identifiable id = new Identifiable();
+        id.setId("abcdef");
+        patientInfo.getIds().add(id);
+        Identifiable id2 = new Identifiable();
+        id2.setId("ghijkl");
+        patientInfo.getIds().add(id2);
+
+        Name name = new Name();
+        name.setFamilyName("Joman");
+        patientInfo.setName(name);
+
+        Address address = new Address();
+        address.setStreetAddress("Jo Str. 3");
+        patientInfo.setAddress(address);
+
+        patientInfo.setDateOfBirth("1234");
+        patientInfo.setGender("A");
+
+        List<String> hl7Data = transformer.toHL7(patientInfo);
+        assertEquals(6, hl7Data.size());
+
+        assertEquals("PID-3|abcdef", hl7Data.get(0));
+        assertEquals("PID-3|ghijkl", hl7Data.get(1));
+        assertEquals("PID-5|Joman", hl7Data.get(2));
+        assertEquals("PID-7|1234", hl7Data.get(3));
+        assertEquals("PID-8|A", hl7Data.get(4));
+        assertEquals("PID-11|Jo Str. 3", hl7Data.get(5));
+    }
+
+    @Test
     public void testToHL7Empty() {
         PatientInfo patientInfo = new PatientInfo();        
         List<String> hl7Data = transformer.toHL7(patientInfo);

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/SubmitObjectsRequestValidatorTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/SubmitObjectsRequestValidatorTest.java
@@ -125,7 +125,7 @@ public class SubmitObjectsRequestValidatorTest {
 
     @Test
     public void testUniqueIdTooLong() {
-        request.getFolders().get(0).setUniqueId("12345678901234567890123456789012345678901234567890123456789012345");
+        request.getFolders().get(0).setUniqueId("123456789012345678901234567890123456789012345678901234567890123451234567890123456789012345678901234567890123456789012345678901234");
         expectFailure(UNIQUE_ID_TOO_LONG);
     }
 
@@ -253,6 +253,13 @@ public class SubmitObjectsRequestValidatorTest {
     }
     
     @Test    
+    public void testUniversalIDToo() {
+        EbXMLProvideAndRegisterDocumentSetRequest ebXML = transformer.toEbXML(request);
+        ebXML.getExtrinsicObjects().get(0).getExternalIdentifiers().get(0).setValue("12");
+        expectFailure(UNIVERSAL_ID_TYPE_MUST_BE_ISO, ebXML);
+    }
+
+    @Test
     public void testHDNeedsUniversalID() {
         EbXMLProvideAndRegisterDocumentSetRequest ebXML = transformer.toEbXML(request);
         ebXML.getExtrinsicObjects().get(0).getExternalIdentifiers().get(0).setValue("12^^^&&ISO");

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/core/DefaultXdsWebService.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/core/DefaultXdsWebService.java
@@ -52,13 +52,18 @@ public class DefaultXdsWebService extends DefaultItiWebService {
         errorInfo.setSeverity(Severity.ERROR);
         errorResponse.getErrors().add(errorInfo);
 
-        if (throwable instanceof XDSMetaDataException)  {
-            XDSMetaDataException exception = (XDSMetaDataException) throwable;
-            if (exception.getValidationMessage().getErrorCode() == null) {
+        XDSMetaDataException metaDataException = null;
+        if ( throwable instanceof XDSMetaDataException)
+            metaDataException = (XDSMetaDataException)throwable;
+        else if ( throwable.getCause() instanceof XDSMetaDataException)
+            metaDataException = (XDSMetaDataException)throwable.getCause(); 
+
+        if (metaDataException != null)  {
+            if (metaDataException.getValidationMessage().getErrorCode() == null) {
                 errorInfo.setErrorCode(defaultMetaDataError);
             }
             else {
-                errorInfo.setErrorCode(exception.getValidationMessage().getErrorCode());
+                errorInfo.setErrorCode(metaDataException.getValidationMessage().getErrorCode());
             }
         }
         else {

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/core/DefaultXdsWebService.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/core/DefaultXdsWebService.java
@@ -48,17 +48,12 @@ public class DefaultXdsWebService extends DefaultItiWebService {
     protected void configureError(Response errorResponse, Throwable throwable, ErrorCode defaultMetaDataError, ErrorCode defaultError) {
         errorResponse.setStatus(Status.FAILURE);
         ErrorInfo errorInfo = new ErrorInfo();
-        errorInfo.setCodeContext(throwable.getMessage());
         errorInfo.setSeverity(Severity.ERROR);
         errorResponse.getErrors().add(errorInfo);
 
-        XDSMetaDataException metaDataException = null;
-        if ( throwable instanceof XDSMetaDataException)
-            metaDataException = (XDSMetaDataException)throwable;
-        else if ( throwable.getCause() instanceof XDSMetaDataException)
-            metaDataException = (XDSMetaDataException)throwable.getCause(); 
-
+        XDSMetaDataException metaDataException = getXDSMetaDataException(throwable);
         if (metaDataException != null)  {
+            errorInfo.setCodeContext(metaDataException.getMessage());
             if (metaDataException.getValidationMessage().getErrorCode() == null) {
                 errorInfo.setErrorCode(defaultMetaDataError);
             }
@@ -67,9 +62,21 @@ public class DefaultXdsWebService extends DefaultItiWebService {
             }
         }
         else {
+            errorInfo.setCodeContext(throwable.getMessage());
             errorInfo.setErrorCode(defaultError);
         }
         
         log.info("Configured error: " + errorResponse);
+    }
+
+    private static XDSMetaDataException getXDSMetaDataException (Throwable throwable)
+    {
+        if ( throwable == null )
+            return null;
+
+        if ( throwable instanceof XDSMetaDataException)
+            return (XDSMetaDataException)throwable;
+        else
+            return getXDSMetaDataException(throwable.getCause());
     }
 }


### PR DESCRIPTION
While trying to upgrade from 2.0.3 to a recent 2.2-SNAPSHOT I noticed that a couple IHE xdstoolkit (xdstest) tests were failing. I tracked the problem down to an extra level of Exception wrapping that was breaking some logic in DefaultXdsWebService.java. The logic was trying to return specific error information based on the type of exception (XDSMetaDataException) and when the exception was wrapped with an additional layer (ValidationException) the algorithm didn’t work quite right. 
