### PR TITLE
XML serialization of simplified model classes

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Address.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Address.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
+
 /**
  * Represents the address of a patient.
  * <p>
@@ -30,17 +32,25 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * removed from the HL7 string.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Address", propOrder = {
+        "streetAddress", "otherDesignation", "city", "countyParishCode", "stateOrProvince", "country", 
+        "zipOrPostalCode"})
 public class Address implements Serializable {
     private static final long serialVersionUID = -5050715144917393181L;
-    
+
     private String streetAddress;               // XAD.1  
-    private String otherDesignation;            // XAD.2  
+    @XmlElement(name = "additionalLocator")
+    private String otherDesignation;            // XAD.2
     private String city;                        // XAD.3  
-    private String stateOrProvince;             // XAD.4  
-    private String zipOrPostalCode;             // XAD.5  
+    @XmlElement(name = "state")
+    private String stateOrProvince;             // XAD.4
+    @XmlElement(name = "postalCode")
+    private String zipOrPostalCode;             // XAD.5
     private String country;                     // XAD.6  
+    @XmlElement(name = "county")
     private String countyParishCode;            // XAD.9  
-    
+
     /**
      * @return the street address (XAD.1).
      */

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AssigningAuthority.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AssigningAuthority.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
+
 /**
  * Represents an authority that assigns IDs.
  * <p>
@@ -35,11 +37,16 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * removed from the HL7 string.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AssigningAuthority")
 public class AssigningAuthority implements Serializable {
     private static final long serialVersionUID = 5350057820250191032L;
     
+    @XmlAttribute
     private String namespaceId;     // HD.1
+    @XmlValue
     private String universalId;     // HD.2
+    @XmlAttribute
     private String universalIdType; // HD.3
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Association.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Association.java
@@ -20,12 +20,18 @@ import java.io.Serializable;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
+
 /**
  * Represents an association between two documents.
  * <p>
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Association", propOrder = {
+        "entryUuid", "sourceUuid", "targetUuid", "associationType", "label", "docCode"})
+@XmlRootElement(name = "association")
 public class Association implements Serializable {
     private static final long serialVersionUID = -4556980177483609469L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AssociationLabel.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AssociationLabel.java
@@ -15,15 +15,21 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * Association labeling values used for the associations of submission sets.
  * @author Jens Riemschneider
  */
+@XmlType(name = "AssociationLabel")
+@XmlEnum(String.class)
 public enum AssociationLabel {
     /** Label for associations to documents that are contained in the request. */
-    ORIGINAL("Original"),
+    @XmlEnumValue("Original") ORIGINAL("Original"),
     /** Label for associations to documents that are only referenced in the request. */
-    REFERENCE("Reference");
+    @XmlEnumValue("Reference") REFERENCE("Reference");
     
     private final String opcode;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AssociationType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AssociationType.java
@@ -15,28 +15,33 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 /**
  * Lists all possible types of associations between two documents.
- * 
+ *
  * @author Jens Riemschneider
  */
+@XmlType(name = "AssociationType")
+@XmlEnum(String.class)
 public enum AssociationType {
     /** An entry that is appended to another one. */
-    APPEND("APND", "urn:ihe:iti:2007:AssociationType:APND"),
+    @XmlEnumValue("APND") APPEND("APND", "urn:ihe:iti:2007:AssociationType:APND"),
     /** An entry that replaced another one. */
-    REPLACE("RPLC", "urn:ihe:iti:2007:AssociationType:RPLC"),
+    @XmlEnumValue("RPLC") REPLACE("RPLC", "urn:ihe:iti:2007:AssociationType:RPLC"),
     /** An entry that transforms another one. */
-    TRANSFORM("XFRM", "urn:ihe:iti:2007:AssociationType:XFRM"),
+    @XmlEnumValue("XFRM") TRANSFORM("XFRM", "urn:ihe:iti:2007:AssociationType:XFRM"),
     /** An entry that transforms and replaces another one. */
-    TRANSFORM_AND_REPLACE("XFRM_RPLC", "urn:ihe:iti:2007:AssociationType:XFRM_RPLC"),
+    @XmlEnumValue("XFRM_RPLC") TRANSFORM_AND_REPLACE("XFRM_RPLC", "urn:ihe:iti:2007:AssociationType:XFRM_RPLC"),
     /** An entry that is a member of another one. */
-    HAS_MEMBER("HasMember", "urn:oasis:names:tc:ebxml-regrep:AssociationType:HasMember"),
+    @XmlEnumValue("HasMember") HAS_MEMBER("HasMember", "urn:oasis:names:tc:ebxml-regrep:AssociationType:HasMember"),
     /** An entry that represents a signature of another one. */
-    SIGNS("signs", "urn:ihe:iti:2007:AssociationType:signs");
+    @XmlEnumValue("signs") SIGNS("signs", "urn:ihe:iti:2007:AssociationType:signs");
 
     private final String opcode21;
     private final String opcode30;
-    
+
     private AssociationType(String opcode21, String opcode30) {
         this.opcode21 = opcode21;
         this.opcode30 = opcode30;
@@ -48,14 +53,14 @@ public enum AssociationType {
     public String getOpcode21() {
         return opcode21;
     }
-    
+
     /**
      * @return a string representation in ebXML 3.0.
      */
     public String getOpcode30() {
         return opcode30;
     }
-    
+
     /**
      * <code>null</code>-safe version of {@link #getOpcode21()}.
      * @param type
@@ -65,7 +70,7 @@ public enum AssociationType {
     public static String getOpcode21(AssociationType type) {
         return type != null ? type.getOpcode21() : null;
     }
-    
+
     /**
      * <code>null</code>-safe version of {@link #getOpcode30()}.
      * @param type
@@ -75,7 +80,7 @@ public enum AssociationType {
     public static String getOpcode30(AssociationType type) {
         return type != null ? type.getOpcode30() : null;
     }
-    
+
     /**
      * Returns the association type that is represented by the given opcode.
      * <p>
@@ -89,16 +94,16 @@ public enum AssociationType {
         if (opcode == null) {
             return null;
         }
-        
+
         for (AssociationType type : AssociationType.values()) {
             if (opcode.equals(type.getOpcode21())) {
                 return type;
             }
         }
-        
+
         return null;
     }
-    
+
     /**
      * Returns the association type that is represented by the given opcode.
      * <p>
@@ -112,16 +117,16 @@ public enum AssociationType {
         if (opcode == null) {
             return null;
         }
-        
+
         for (AssociationType type : AssociationType.values()) {
             if (opcode.equals(type.getOpcode30())) {
                 return type;
             }
         }
-        
+
         return null;
     }
-    
+
     /**
      * @return <code>true</code> if the association contains a replacement.
      */

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Author.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Author.java
@@ -15,6 +15,10 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +34,8 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * 
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Author", propOrder = {"authorPerson", "authorInstitution", "authorSpecialty", "authorRole"})
 public class Author implements Serializable {
     private static final long serialVersionUID = 6731221295927724760L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AvailabilityStatus.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/AvailabilityStatus.java
@@ -15,18 +15,23 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 /**
  * Describes the availability of an entry.
  * 
  * @author Jens Riemschneider
  */
+@XmlType(name = "AvailabilityStatus")
+@XmlEnum(String.class)
 public enum AvailabilityStatus {
     /** The entry is approved. */
-    APPROVED("Approved", "urn:oasis:names:tc:ebxml-regrep:StatusType:Approved"),
+    @XmlEnumValue("Approved") APPROVED("Approved", "urn:oasis:names:tc:ebxml-regrep:StatusType:Approved"),
     /** The entry is deprecated. */
-    DEPRECATED("Deprecated", "urn:oasis:names:tc:ebxml-regrep:StatusType:Deprecated"),
+    @XmlEnumValue("Deprecated") DEPRECATED("Deprecated", "urn:oasis:names:tc:ebxml-regrep:StatusType:Deprecated"),
     /** The entry is submitted. */
-    SUBMITTED("Submitted", "urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted");
+    @XmlEnumValue("Submitted") SUBMITTED("Submitted", "urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted");
     
     private final String opcode;
     private final String queryOpcode;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Code.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Code.java
@@ -20,17 +20,26 @@ import java.io.Serializable;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
 /**
  * Represents a code.
  * <p> 
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Code", propOrder = {"code", "schemeName", "displayName"})
 public class Code implements Serializable {
     private static final long serialVersionUID = 7603534956639945984L;
     
+    @XmlAttribute
     private String code;
+    @XmlAttribute
+    @XmlJavaTypeAdapter(value = SimplifiedLocalizedStringAdapter.class)
     private LocalizedString displayName;
+    @XmlAttribute(name="codeSystemName")
     private String schemeName;
     
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Document.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Document.java
@@ -18,6 +18,7 @@ package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 import java.io.Serializable;
 
 import javax.activation.DataHandler;
+import javax.xml.bind.annotation.*;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
@@ -28,6 +29,9 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Document")
+@XmlRootElement(name = "document")
 public class Document implements Serializable {
     private static final long serialVersionUID = 5206884085835642756L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/DocumentEntry.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/DocumentEntry.java
@@ -18,6 +18,8 @@ package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,13 +32,25 @@ import java.util.List;
  * 
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DocumentEntry", propOrder = {
+        "sourcePatientId", "sourcePatientInfo", "creationTime", "authors", "legalAuthenticator", "serviceStartTime",
+        "serviceStopTime", "classCode", "confidentialityCodes", "eventCodeList", "formatCode",
+        "healthcareFacilityTypeCode", "languageCode", "practiceSettingCode", "typeCode", "repositoryUniqueId",
+        "mimeType", "size", "hash", "uri"})
+@XmlRootElement(name = "documentEntry")
 public class DocumentEntry extends XDSMetaClass implements Serializable {
     private static final long serialVersionUID = -4779500440504776909L;
     
+    @XmlElement(name = "author")
     private final List<Author> authors = new ArrayList<Author>();
     private Code classCode;
+    @XmlElement(name = "confidentialityCode")
     private final List<Code> confidentialityCodes = new ArrayList<Code>();
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String creationTime;
+    @XmlElement(name = "eventCode")
     private final List<Code> eventCodeList = new ArrayList<Code>();
     private Code formatCode;
     private String hash;
@@ -45,7 +59,11 @@ public class DocumentEntry extends XDSMetaClass implements Serializable {
     private Person legalAuthenticator;
     private String mimeType;
     private Code practiceSettingCode;
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String serviceStartTime;
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String serviceStopTime;
     private Long size;
     private Identifiable sourcePatientId;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Folder.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Folder.java
@@ -15,6 +15,8 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,10 +32,16 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * 
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Folder", propOrder = {"lastUpdateTime", "codeList"})
+@XmlRootElement(name = "folder")
 public class Folder extends XDSMetaClass implements Serializable {
     private static final long serialVersionUID = -1923451867453561796L;
     
+    @XmlElement(name = "code")
     private final List<Code> codeList = new ArrayList<Code>();
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String lastUpdateTime;
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/IHEDateAdapter.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/IHEDateAdapter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.metadata;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
+
+/**
+ * A JAXB {@link XmlAdapter} that translates between the IHE XDS date format and a more native XML date format.
+ * <p/>
+ * Note that the variable precision nature of the IHE XDS date format makes it difficult to create a conversion
+ * that can survive a round trip from IHE XDS to Java date and back and come out EXACTLY the same. The current
+ * code tries to infer the necessary output precision of an IHE XDS date. The date that pops out should be a
+ * proper representation of the Java date but may not look EXACTLY the same as the input to the round trip because
+ * there are multiple ways to represent the same thing. For example, 2011030108 means the same time as 201103010800.
+ */
+public class IHEDateAdapter extends XmlAdapter<Calendar, String> {
+    /**
+     * Converts an IHE XDS date in String format into a Java date in Calendar format.
+     *
+     * @param v an IHE XDS date in String format
+     * @return a Java date in Calendar format
+     * @throws Exception
+     */
+    @Override
+    public Calendar marshal(String v) throws Exception {
+        if (v == null)
+            return null;
+
+        String[] parts = v.split("[-+]");
+
+        // Isolate the core date portion.
+        String dateString = parts[0];
+        if (dateString.length() > 19)
+            throw new IllegalArgumentException();
+        if (dateString.length() > 14 && dateString.charAt(14) != '.')
+            throw new IllegalArgumentException();
+
+        // Isolate the offset portion (if it exists).
+        String offsetString = parts.length > 1 ? parts[1] : null;
+        if (offsetString != null && offsetString.length() != 4)
+            throw new IllegalArgumentException();
+
+        // Calculate the time zone. It defaults to GMT.
+        int offsetInMilliseconds = getOffset(parts.length > 1 ? parts[1] : null, v.contains("-"));
+        TimeZone timeZone = new SimpleTimeZone(offsetInMilliseconds, offsetString == null ? "GMT" : offsetString);
+
+        // Transfer fields from the IHE date to the Calendar.
+        GregorianCalendar calendar = new GregorianCalendar(timeZone);
+        calendar.set(Calendar.YEAR, getFieldValue(dateString, 0, 4));
+        int month = getFieldValue(dateString, 4, 2);
+        calendar.set(Calendar.MONTH, month == 0 ? 0 : month - 1); // Calendar value is zero-based
+        int day = getFieldValue(dateString, 6, 2);
+        calendar.set(Calendar.DAY_OF_MONTH, day == 0 ? 1 : day);
+        calendar.set(Calendar.HOUR_OF_DAY, getFieldValue(dateString, 8, 2));
+        calendar.set(Calendar.MINUTE, getFieldValue(dateString, 10, 2));
+        calendar.set(Calendar.SECOND, getFieldValue(dateString, 12, 2));
+        calendar.set(Calendar.MILLISECOND, getLastFieldValue(dateString, 15, 4) / 10);
+        return calendar;
+    }
+
+    /**
+     * Converts a Java date in Calendar format into an IHE XDS date in String format.
+     *
+     * @param v a Java date in Calendar format
+     * @return an IHE XDS date in String format
+     * @throws Exception
+     */
+    @Override
+    public String unmarshal(Calendar v) throws Exception {
+        String mainPart =
+                String.format(
+                        getFormatForSignificantPart(v),
+                        v.get(Calendar.YEAR),
+                        v.get(Calendar.MONTH) + 1,
+                        v.get(Calendar.DAY_OF_MONTH),
+                        v.get(Calendar.HOUR_OF_DAY),
+                        v.get(Calendar.MINUTE),
+                        v.get(Calendar.SECOND),
+                        v.get(Calendar.MILLISECOND));
+
+        if (v.getTimeZone().getRawOffset() != 0) {
+            String offsetPart = String.format("%+05d", v.getTimeZone().getRawOffset());
+            return mainPart + offsetPart;
+        } else
+            return mainPart;
+    }
+
+    private int getOffset(String offsetString, boolean negative) {
+        if (offsetString != null) {
+
+            int hours = getFieldValue(offsetString, 0, 2);
+            int minutes = getFieldValue(offsetString, 2, 2);
+            return (((hours * 60) + minutes) * 60 * 1000) * (negative ? -1 : 1);
+        } else
+            return 0;
+    }
+
+    private int getFieldValue(String input, int fieldOffset, int fieldLength) {
+        if (input.length() < (fieldOffset + fieldLength))
+            return 0;
+
+        return Integer.valueOf(input.substring(fieldOffset, fieldOffset + fieldLength));
+    }
+
+    private int getLastFieldValue(String input, int fieldOffset, int maximumLength) {
+        int remainingLength = input.length() - fieldOffset;
+        if (remainingLength <= 0)
+            return 0;
+
+        int value = Integer.valueOf(input.substring(fieldOffset, fieldOffset + remainingLength));
+        for (int i = remainingLength; i < maximumLength; i++)
+            value *= 10;
+
+        return value;
+    }
+
+    private String getFormatForSignificantPart(Calendar value) {
+        if (value.get(Calendar.MILLISECOND) > 0)
+            return "%04d%02d%02d%02d%02d%02d.%03d";
+        if (value.get(Calendar.SECOND) > 0)
+            return "%04d%02d%02d%02d%02d%02d";
+        if (value.get(Calendar.MINUTE) > 0)
+            return "%04d%02d%02d%02d%02d";
+        if (value.get(Calendar.HOUR_OF_DAY) > 0)
+            return "%04d%02d%02d%02d";
+        if (value.get(Calendar.DAY_OF_MONTH) > 1)
+            return "%04d%02d%02d";
+        if (value.get(Calendar.MONTH) > 0)
+            return "%04d%02d";
+
+        return "%04d";
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Identifiable.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Identifiable.java
@@ -15,6 +15,8 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -31,10 +33,15 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * removed from the HL7 string.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Identifiable", propOrder = {"id", "assigningAuthority"})
 public class Identifiable implements Serializable {
     private static final long serialVersionUID = -3392755556068006520L;
-    
+
+    @XmlAttribute(name = "extension")
     private String id;                                // CX.1
+    @XmlAttribute(name = "root")
+    @XmlJavaTypeAdapter(value = SimplifiedAssigningAuthorityAdapter.class)
     private AssigningAuthority assigningAuthority;    // CX.4
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/LocalizedString.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/LocalizedString.java
@@ -15,6 +15,8 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -27,17 +29,25 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * 
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "LocalizedString")
 public class LocalizedString implements Serializable {
     private static final long serialVersionUID = 4876325465142358849L;
     
+    @XmlAttribute(name = "language")
     private String lang;
+    @XmlTransient
     private String charset;
+    @XmlValue
     private String value;
     
     /**
      * Constructs a localized string.
      */
-    public LocalizedString() {}
+    public LocalizedString() {
+        lang = "en-US";
+        charset = "UTF-8";
+    }
 
     /**
      * Constructs a localized string.
@@ -62,7 +72,7 @@ public class LocalizedString implements Serializable {
     public LocalizedString(String value) {
         this.value = value;
         lang = "en-US";
-        charset = "UTF8";
+        charset = "UTF-8";
     }
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Name.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Name.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -31,11 +32,16 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * removed from the HL7 string.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Name", propOrder = {"prefix", "givenName", "secondAndFurtherGivenNames", "familyName", "suffix"})
 public class Name implements Serializable {
     private static final long serialVersionUID = -3455779057944896901L;
-    
+
+    @XmlElement(name = "family")
     private String familyName;                  // XCN.2.1, XPN.1.1
+    @XmlElement(name = "given")
     private String givenName;                   // XCN.3, XPN.2
+    @XmlElement(name = "secondAndFurtherGiven")
     private String secondAndFurtherGivenNames;  // XCN.4, XPN.3
     private String suffix;                      // XCN.5, XPN.4
     private String prefix;                      // XCN.6, XPN.5

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/ObjectReference.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/ObjectReference.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -24,10 +25,14 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * Represents an object reference.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ObjectReference", propOrder = {"home", "id"})
 public class ObjectReference implements Serializable {
     private static final long serialVersionUID = 5442558815484966722L;
-    
+
+    @XmlAttribute(name = "uuid")
     private String id;
+    @XmlAttribute(name = "homeCommunityId")
     private String home;
     
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Organization.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Organization.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -30,12 +31,14 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * removed from the HL7 string.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Organization", propOrder = {"id", "organizationName"})
 public class Organization implements Serializable {
     private static final long serialVersionUID = 8283797476558181158L;
-    
+
+    @XmlElement(name = "name")
     private String organizationName;                // XON.1
-    private AssigningAuthority assigningAuthority;  // XON.6
-    private String idNumber;                        // XON.10
+    private Identifiable id;
 
     /**
      * Constructs the organization.
@@ -62,15 +65,15 @@ public class Organization implements Serializable {
      */
     public Organization(String organizationName, String idNumber, AssigningAuthority assigningAuthority) {
         this.organizationName = organizationName;
-        this.idNumber = idNumber;
-        this.assigningAuthority = assigningAuthority;
+        this.id = new Identifiable(idNumber, assigningAuthority);
+        normalizeEmptyId();
     }
 
     /**
      * @return the assigning authority (XON.6).
      */
     public AssigningAuthority getAssigningAuthority() {
-        return assigningAuthority;
+        return id == null ? null : id.getAssigningAuthority();
     }
     
     /**
@@ -78,7 +81,9 @@ public class Organization implements Serializable {
      *          the assigning authority (XON.6).
      */
     public void setAssigningAuthority(AssigningAuthority assigningAuthority) {
-        this.assigningAuthority = assigningAuthority;
+        lazilyCreateIdIfNecessary();
+        id.setAssigningAuthority(assigningAuthority);
+        normalizeEmptyId();
     }
 
     /**
@@ -100,7 +105,7 @@ public class Organization implements Serializable {
      * @return the id of the organization (XON.10).
      */
     public String getIdNumber() {
-        return idNumber;
+        return id == null ? null : id.getId();
     }
 
     /**
@@ -108,16 +113,16 @@ public class Organization implements Serializable {
      *          the id of the organization (XON.10).
      */
     public void setIdNumber(String idNumber) {
-        this.idNumber = idNumber;
+        lazilyCreateIdIfNecessary();
+        id.setId(idNumber);
+        normalizeEmptyId();
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((assigningAuthority == null) ? 0 : assigningAuthority.hashCode());
-        result = prime * result + ((idNumber == null) ? 0 : idNumber.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
         result = prime * result + ((organizationName == null) ? 0 : organizationName.hashCode());
         return result;
     }
@@ -131,15 +136,10 @@ public class Organization implements Serializable {
         if (getClass() != obj.getClass())
             return false;
         Organization other = (Organization) obj;
-        if (assigningAuthority == null) {
-            if (other.assigningAuthority != null)
+        if (id == null) {
+            if (other.id != null)
                 return false;
-        } else if (!assigningAuthority.equals(other.assigningAuthority))
-            return false;
-        if (idNumber == null) {
-            if (other.idNumber != null)
-                return false;
-        } else if (!idNumber.equals(other.idNumber))
+        } else if (!id.equals(other.id))
             return false;
         if (organizationName == null) {
             if (other.organizationName != null)
@@ -152,5 +152,18 @@ public class Organization implements Serializable {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+    private void normalizeEmptyId() {
+        if ( id.getId() == null && id.getAssigningAuthority() == null) {
+            id = null;
+        }
+    }
+
+    private void lazilyCreateIdIfNecessary()
+    {
+        if ( id == null ) {
+            id = new Identifiable();
+        }
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/PatientInfo.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/PatientInfo.java
@@ -15,6 +15,8 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,11 +37,17 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * Lists are pre-created and can therefore never be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PatientInfo", propOrder = {"ids", "name", "gender", "dateOfBirth", "address"})
 public class PatientInfo implements Serializable {
     private static final long serialVersionUID = 7202574584233259959L;
-    
+
+    @XmlElement(name = "id")
     private final List<Identifiable> ids = new ArrayList<Identifiable>();   // PID-3
     private Name name;                                                      // PID-5
+    @XmlElement(name = "birthTime")
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String dateOfBirth;                                             // PID-7
     private String gender;                                                  // PID-8
     private Address address;                                                // PID-11

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Person.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Person.java
@@ -15,6 +15,9 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -32,6 +35,8 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * values are removed from the HL7 string.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Person", propOrder = {"id", "name"})
 public class Person implements Serializable {    
     private static final long serialVersionUID = 1775227207521668959L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Recipient.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Recipient.java
@@ -15,6 +15,9 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -29,6 +32,8 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * expected to be a member of the specified organization.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Recipient", propOrder = {"person", "organization"})
 public class Recipient implements Serializable {
     private static final long serialVersionUID = -8192511869759795939L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/SimplifiedAssigningAuthorityAdapter.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/SimplifiedAssigningAuthorityAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.metadata;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * A JAXB {@link XmlAdapter} that creates a simplified representation of an {@link AssigningAuthority} which just
+ * contains the universal id without the namespace id and the universal id type. In XDS these fields are not
+ * used and they get in the way when trying to serialize in a simple HL7 V3 format.
+ */
+public class SimplifiedAssigningAuthorityAdapter extends XmlAdapter<String, AssigningAuthority> {
+    @Override
+    public String marshal(AssigningAuthority v) throws Exception {
+        if (v == null)
+            return null;
+
+        return v.getUniversalId();
+    }
+
+    @Override
+    public AssigningAuthority unmarshal(String v) throws Exception {
+        return new AssigningAuthority(v);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/SimplifiedLocalizedStringAdapter.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/SimplifiedLocalizedStringAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.metadata;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * A JAXB {@link XmlAdapter} that creates a simplified representation of a {@link LocalizedString} which just
+ * contains the string itself without the language and charset information. There is at least one case in the
+ * HL7 V3 serialization in which this simplified representation is needed.
+ */
+public class SimplifiedLocalizedStringAdapter extends XmlAdapter<String, LocalizedString> {
+    @Override
+    public String marshal(LocalizedString v) throws Exception {
+        if (v == null)
+            return null;
+
+        return v.getValue();
+    }
+
+    @Override
+    public LocalizedString unmarshal(String v) throws Exception {
+        return new LocalizedString(v);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/SubmissionSet.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/SubmissionSet.java
@@ -18,6 +18,8 @@ package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,13 +32,21 @@ import java.util.List;
  * 
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SubmissionSet", propOrder = {
+        "sourceId", "submissionTime", "authors", "intendedRecipients", "contentTypeCode"})
+@XmlRootElement(name = "submissionSet")
 public class SubmissionSet extends XDSMetaClass implements Serializable {
     private static final long serialVersionUID = 5961980266312684583L;
     
+    @XmlElement(name = "author")
     private final List<Author> authors = new ArrayList<Author>();
     private Code contentTypeCode;
+    @XmlElement(name = "intendedRecipient")
     private final List<Recipient> intendedRecipients = new ArrayList<Recipient>(); 
     private String sourceId;
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String submissionTime;
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/TimeRange.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/TimeRange.java
@@ -15,6 +15,8 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -24,10 +26,18 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * Represents a date and time range used in queries.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TimeRange", propOrder = {"from", "to"})
 public class TimeRange implements Serializable {
     private static final long serialVersionUID = -5468726370729209318L;
     
+    @XmlAttribute
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String from;
+    @XmlAttribute
+    @XmlSchemaType(name = "dateTime")
+    @XmlJavaTypeAdapter(value = IHEDateAdapter.class)
     private String to;
     
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Version.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Version.java
@@ -18,8 +18,11 @@ package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Version")
 public class Version implements Serializable {
     private static final long serialVersionUID = 4876325465142352011L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/XDSMetaClass.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/XDSMetaClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2009-2011 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.metadata;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -26,6 +29,9 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IdentifiedObject", propOrder = {
+        "homeCommunityId", "entryUuid", "logicalUuid", "version", "uniqueId", "patientId", "availabilityStatus", "title", "comments"})
 public abstract class XDSMetaClass implements Serializable {
     private static final long serialVersionUID = -1193012076778493996L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/package-info.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@XmlSchema(
+        namespace = "http://www.openehealth.org/ipf/xds",
+        elementFormDefault = XmlNsForm.UNQUALIFIED,
+        attributeFormDefault = XmlNsForm.UNQUALIFIED,
+        xmlns = {@XmlNs(prefix = "xds", namespaceURI = "http://www.openehealth.org/ipf/xds")})
+package org.openehealth.ipf.commons.ihe.xds.core.metadata;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/ProvideAndRegisterDocumentSet.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/ProvideAndRegisterDocumentSet.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,12 +34,20 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.SubmissionSet;
  * The lists are pre-created and can therefore never be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ProvideAndRegisterDocumentSet", propOrder = {
+        "submissionSet", "folders", "documents", "associations"})
+@XmlRootElement(name = "provideAndRegisterDocumentSet")
 public class ProvideAndRegisterDocumentSet implements Serializable {
     private static final long serialVersionUID = -746285879968609663L;
     
+    @XmlElementRef
     private SubmissionSet submissionSet;
+    @XmlElementRef
     private final List<Folder> folders = new ArrayList<Folder>();
+    @XmlElementRef
     private final List<Document> documents = new ArrayList<Document>();
+    @XmlElementRef
     private final List<Association> associations = new ArrayList<Association>();
     
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/QueryRegistry.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/QueryRegistry.java
@@ -18,20 +18,45 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests;
 import static org.apache.commons.lang.Validate.notNull;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
-import org.openehealth.ipf.commons.ihe.xds.core.requests.query.Query;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.*;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Request object for the Query Registry and Registry Stored Query transactions.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "QueryRegistry")
+@XmlRootElement(name = "queryRegistry")
 public class QueryRegistry implements Serializable {
     private static final long serialVersionUID = -7089029668323133489L;
 
-    private final Query query;
-    
+    @XmlElementRefs({
+            @XmlElementRef(type = FindDocumentsQuery.class),
+            @XmlElementRef(type = FindFoldersQuery.class),
+            @XmlElementRef(type = FindSubmissionSetsQuery.class),
+            @XmlElementRef(type = GetAllQuery.class),
+            @XmlElementRef(type = GetAssociationsQuery.class),
+            @XmlElementRef(type = GetDocumentsAndAssociationsQuery.class),
+            @XmlElementRef(type = GetDocumentsQuery.class),
+            @XmlElementRef(type = GetFolderAndContentsQuery.class),
+            @XmlElementRef(type = GetFoldersForDocumentQuery.class),
+            @XmlElementRef(type = GetFoldersQuery.class),
+            @XmlElementRef(type = GetFromDocumentQuery.class),
+            @XmlElementRef(type = GetRelatedDocumentsQuery.class),
+            @XmlElementRef(type = GetSubmissionSetAndContentsQuery.class),
+            @XmlElementRef(type = GetSubmissionSetsQuery.class)})
+    private Query query;
+    @XmlAttribute
     private boolean returnLeafObjects;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public QueryRegistry() {
+    }
 
     /**
      * Constructs the request.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RegisterDocumentSet.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RegisterDocumentSet.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,12 +34,20 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.SubmissionSet;
  * The lists are pre-created and can therefore never be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "RegisterDocumentSet", propOrder = {
+        "submissionSet", "folders", "documentEntries", "associations"})
+@XmlRootElement(name = "registerDocumentSet")
 public class RegisterDocumentSet implements Serializable {
     private static final long serialVersionUID = 4029172072096691799L;
     
+    @XmlElementRef
     private SubmissionSet submissionSet;
+    @XmlElementRef
     private final List<Folder> folders = new ArrayList<Folder>();
+    @XmlElementRef
     private final List<DocumentEntry> documentEntries = new ArrayList<DocumentEntry>();
+    @XmlElementRef
     private final List<Association> associations = new ArrayList<Association>();
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RetrieveDocument.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RetrieveDocument.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -26,6 +27,10 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "RetrieveDocument", propOrder = {"homeCommunityId", "repositoryUniqueId", "documentUniqueId" })
+@XmlRootElement(name = "retrieveDocument")
 public class RetrieveDocument implements Serializable {
     private static final long serialVersionUID = 7147966094676034661L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RetrieveDocumentSet.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RetrieveDocumentSet.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +29,14 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * Lists are pre-created and can therefore never be <code>null</code>.
  * @author Jens Riemschneider
  */
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "RetrieveDocumentSet")
+@XmlRootElement(name = "retrieveDocumentSet")
 public class RetrieveDocumentSet implements Serializable {
     private static final long serialVersionUID = -3410625944194160618L;
     
+    @XmlElementRef
     private final List<RetrieveDocument> documents = new ArrayList<RetrieveDocument>();
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/package-info.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/package-info.java
@@ -1,0 +1,11 @@
+@XmlSchema(
+        namespace = "http://www.openehealth.org/ipf/xds",
+        elementFormDefault = XmlNsForm.UNQUALIFIED,
+        attributeFormDefault = XmlNsForm.UNQUALIFIED,
+        xmlns = {
+                @XmlNs(prefix = "xds", namespaceURI = "http://www.openehealth.org/ipf/xds")})
+package org.openehealth.ipf.commons.ihe.xds.core.requests;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindDocumentsQuery.java
@@ -17,6 +17,7 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.*;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
 
@@ -24,19 +25,33 @@ import java.util.List;
  * Represents a stored query for FindDocuments.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindDocumentsQuery", propOrder = {
+        "status", "authorPersons", "creationTime", "serviceStartTime", "serviceStopTime", "classCodes",
+        "confidentialityCodes", "eventCodes", "formatCodes", "healthcareFacilityTypeCodes", "practiceSettingCodes",
+        "typeCodes"})
+@XmlRootElement(name = "findDocumentsQuery")
 public class FindDocumentsQuery extends PatientIdBasedStoredQuery implements Serializable {
     private static final long serialVersionUID = -5765363916663583605L;
 
     private List<AvailabilityStatus> status;
+    @XmlElement(name = "typeCode")
     private List<Code> typeCodes;
+    @XmlElement(name = "classCode")
     private List<Code> classCodes;
+    @XmlElement(name = "practiceSettingCode")
     private List<Code> practiceSettingCodes;
+    @XmlElement(name = "healthcareFacilityTypeCode")
     private List<Code> healthcareFacilityTypeCodes;
+    @XmlElement(name = "eventCode")
     private QueryList<Code> eventCodes;
+    @XmlElement(name = "confidentialityCode")
     private QueryList<Code> confidentialityCodes;
+    @XmlElement(name = "formatCode")
     private List<Code> formatCodes;
+    @XmlElement(name = "authorPerson")
     private List<String> authorPersons;
-    
+
     private final TimeRange creationTime = new TimeRange();
     private final TimeRange serviceStartTime = new TimeRange();
     private final TimeRange serviceStopTime = new TimeRange();

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindFoldersQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindFoldersQuery.java
@@ -15,19 +15,27 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.*;
-
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
+
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Folder;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.TimeRange;
 
 /**
  * Represents a stored query for FindFolders.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindFoldersQuery", propOrder = {"status", "lastUpdateTime", "codes"})
+@XmlRootElement(name = "findFoldersQuery")
 public class FindFoldersQuery extends PatientIdBasedStoredQuery implements Serializable {
     private static final long serialVersionUID = 4156643982985304259L;
 
     private List<AvailabilityStatus> status;
+    @XmlElement(name = "code")
     private QueryList<Code> codes;
     
     private final TimeRange lastUpdateTime = new TimeRange();

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindSubmissionSetsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindSubmissionSetsQuery.java
@@ -17,6 +17,7 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.*;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
 
@@ -24,14 +25,20 @@ import java.util.List;
  * Represents a stored query for FindSubmissionSets.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindSubmissionSetsQuery", propOrder = {
+        "status", "sourceIds", "authorPerson", "submissionTime", "contentTypeCodes"})
+@XmlRootElement(name = "findSubmissionSetsQuery")
 public class FindSubmissionSetsQuery extends PatientIdBasedStoredQuery implements Serializable {
     private static final long serialVersionUID = 1712346604151312305L;
 
     private List<AvailabilityStatus> status;
+    @XmlElement(name = "sourceId")
     private List<String> sourceIds;
+    @XmlElement(name = "contentTypeCode")
     private List<Code> contentTypeCodes;
     private String authorPerson;
-    
+
     private final TimeRange submissionTime = new TimeRange();
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetAllQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetAllQuery.java
@@ -15,23 +15,37 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.*;
-
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
+
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntry;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Folder;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.SubmissionSet;
 
 /**
  * Represents a stored query for GetAll.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetAllQuery", propOrder = {
+        "statusDocuments", "statusSubmissionSets", "statusFolders", "confidentialityCodes", "formatCodes"})
+@XmlRootElement(name = "getAllQuery")
 public class GetAllQuery extends PatientIdBasedStoredQuery implements Serializable {
     private static final long serialVersionUID = -4161172318244319631L;
 
+    @XmlElement(name = "documentStatus")
     private List<AvailabilityStatus> statusDocuments;
+    @XmlElement(name = "submissionSetStatus")
     private List<AvailabilityStatus> statusSubmissionSets;
+    @XmlElement(name = "folderStatus")
     private List<AvailabilityStatus> statusFolders;
 
+    @XmlElement(name = "confidentialityCode")
     private QueryList<Code> confidentialityCodes;
+    @XmlElement(name = "formatCode")
     private List<Code> formatCodes;
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetAssociationsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetAssociationsQuery.java
@@ -15,12 +15,16 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Represents a stored query for GetAssociations.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetAssociationsQuery")
+@XmlRootElement(name = "getAssociationsQuery")
 public class GetAssociationsQuery extends GetByUuidQuery implements Serializable {
     private static final long serialVersionUID = 5623733746377113397L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetByIdAndCodesQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetByIdAndCodesQuery.java
@@ -15,11 +15,12 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntry;
-
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
+
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntry;
 
 /**
  * Base class for queries that are defined by:
@@ -28,12 +29,22 @@ import java.util.List;
  * <li> a list of confidentiality codes
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetByIdAndCodesQuery", propOrder = {"confidentialityCodes", "formatCodes"})
 public abstract class GetByIdAndCodesQuery extends GetFromDocumentQuery implements Serializable {
     private static final long serialVersionUID = -8311996966550912396L;
-    
+
+    @XmlElement(name = "confidentialityCode")
     private QueryList<Code> confidentialityCodes;
+    @XmlElement(name = "formatCode")
     private List<Code> formatCodes;
-    
+
+    /**
+     * For JAXB serialization only.
+     */
+    public GetByIdAndCodesQuery() {
+    }
+
     /**
      * Constructs the query.
      * @param type

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetByIdQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetByIdQuery.java
@@ -15,19 +15,28 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.XDSMetaClass;
-
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
+
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.XDSMetaClass;
 
 /**
  * Base class for queries that are defined by a list of UUIDs or unique IDs. 
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetByIdQuery")
 public abstract class GetByIdQuery extends GetByUuidQuery implements Serializable {
     private static final long serialVersionUID = -3955280836816390271L;
-    
+    @XmlElement(name = "uniqueId")
     private List<String> uniqueIds;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public GetByIdQuery() {
+    }
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetByUuidQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetByUuidQuery.java
@@ -15,19 +15,29 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.XDSMetaClass;
-
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
+
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.XDSMetaClass;
 
 /**
  * Base class for queries that are defined by a list of UUIDs. 
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetByUuidQuery", propOrder = {"uuids"})
 public abstract class GetByUuidQuery extends StoredQuery implements Serializable {
     private static final long serialVersionUID = -7962722576557371093L;
-    
+
+    @XmlElement(name = "uuid")
     private List<String> uuids;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public GetByUuidQuery() {
+    }
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetDocumentsAndAssociationsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetDocumentsAndAssociationsQuery.java
@@ -15,12 +15,16 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Represents a stored query for GetDocumentsAndAssociations.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetDocumentsAndAssociationsQuery")
+@XmlRootElement(name = "getDocumentsAndAssociationsQuery")
 public class GetDocumentsAndAssociationsQuery extends GetByIdQuery implements Serializable {
     private static final long serialVersionUID = 7120944927521427681L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetDocumentsQuery.java
@@ -15,12 +15,16 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Represents a stored query for GetDocuments.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetDocumentsQuery")
+@XmlRootElement(name = "getDocumentsQuery")
 public class GetDocumentsQuery extends GetByIdQuery implements Serializable {
     private static final long serialVersionUID = 3610389657970005956L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFolderAndContentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFolderAndContentsQuery.java
@@ -15,12 +15,16 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Represents a stored query for GetFolderAndContents.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetFolderAndContentsQuery")
+@XmlRootElement(name = "getFolderAndContentsQuery")
 public class GetFolderAndContentsQuery extends GetByIdAndCodesQuery implements Serializable {
     private static final long serialVersionUID = -5400326849236563094L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFoldersForDocumentQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFoldersForDocumentQuery.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 
@@ -22,6 +23,9 @@ import java.io.Serializable;
  * Represents a stored query for GetFoldersForDocument.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetFoldersForDocumentQuery")
+@XmlRootElement(name = "getFoldersForDocumentQuery")
 public class GetFoldersForDocumentQuery extends GetFromDocumentQuery implements Serializable {
     private static final long serialVersionUID = 4576256132617368775L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFoldersQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFoldersQuery.java
@@ -15,12 +15,16 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Represents a stored query for GetFolders.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetFoldersQuery")
+@XmlRootElement(name = "getFoldersQuery")
 public class GetFoldersQuery extends GetByIdQuery implements Serializable {
     private static final long serialVersionUID = 854601731250203237L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFromDocumentQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetFromDocumentQuery.java
@@ -15,19 +15,28 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntry;
-
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
+
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntry;
 
 /**
  * Base class for queries that retrieve results via a document entry.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetFromDocumentQuery", propOrder = {"uuid", "uniqueId" })
 public abstract class GetFromDocumentQuery extends StoredQuery implements Serializable {
     private static final long serialVersionUID = 627720659958894242L;
     
     private String uuid;
     private String uniqueId;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public GetFromDocumentQuery() {
+    }
 
     /**
      * Constructs the query.
@@ -67,7 +76,6 @@ public abstract class GetFromDocumentQuery extends StoredQuery implements Serial
     public void setUniqueId(String uniqueId) {
         this.uniqueId = uniqueId;
     }
-
 
     @Override
     public int hashCode() {

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetRelatedDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetRelatedDocumentsQuery.java
@@ -15,19 +15,24 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Association;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssociationType;
-
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.List;
+
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Association;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssociationType;
 
 /**
  * Represents a stored query for GetRelatedDocuments.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetRelatedDocumentsQuery")
+@XmlRootElement(name = "getRelatedDocumentsQuery")
 public class GetRelatedDocumentsQuery extends GetFromDocumentQuery implements Serializable {
     private static final long serialVersionUID = -8768793068458839362L;
-    
+
+    @XmlElement(name = "associationType")
     private List<AssociationType> associationTypes;
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetSubmissionSetAndContentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetSubmissionSetAndContentsQuery.java
@@ -15,12 +15,16 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Represents a stored query for GetSubmissionSetAndContents.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetSubmissionSetAndContentsQuery")
+@XmlRootElement(name = "getSubmissionSetAndContentsQuery")
 public class GetSubmissionSetAndContentsQuery extends GetByIdAndCodesQuery implements Serializable {
     private static final long serialVersionUID = -4883836034076616558L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetSubmissionSetsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/GetSubmissionSetsQuery.java
@@ -15,12 +15,16 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Represents a stored query for GetSubmissionSets.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetSubmissionSetsQuery")
+@XmlRootElement(name = "getSubmissionSetsQuery")
 public class GetSubmissionSetsQuery extends GetByUuidQuery implements Serializable {
     private static final long serialVersionUID = 2089514690641582428L;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/ListOfListAdapter.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/ListOfListAdapter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A JAXB {@link XmlAdapter} that helps serialize generic lists of lists. This sort of thing is used by the
+ * IPF {@link QueryList} class but is not handled naturally by JAXB. It takes a little effort here to get a
+ * reasonable serialization.
+ *
+ * @param <T> The type of object contained in the inner list
+ */
+public class ListOfListAdapter<T> extends XmlAdapter<ListOfListAdapter.ListOfListWrapper<T>, List<List<T>>> {
+    @Override
+    public List<List<T>> unmarshal(ListOfListWrapper<T> v) throws Exception {
+        List<List<T>> outerList = new ArrayList<List<T>>();
+        for (ListWrapper<T> innerList : v.getInnerList())
+            outerList.add(innerList.getValue());
+
+        return outerList;
+    }
+
+    @Override
+    public ListOfListWrapper<T> marshal(List<List<T>> v) throws Exception {
+        List<ListWrapper<T>> outerList = new ArrayList<ListWrapper<T>>();
+        for (List<T> innerList : v)
+            outerList.add(new ListWrapper<T>(innerList));
+
+        return new ListOfListWrapper<T>(outerList);
+    }
+
+    @XmlType
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class ListOfListWrapper<T> {
+        private List<ListWrapper<T>> innerList;
+
+        // Required for JAXB
+
+        @SuppressWarnings({"UnusedDeclaration"})
+        public ListOfListWrapper() {
+        }
+
+        public ListOfListWrapper(List<ListWrapper<T>> list) {
+            this.innerList = list;
+        }
+
+        public List<ListWrapper<T>> getInnerList() {
+            return innerList;
+        }
+    }
+
+    @XmlType
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class ListWrapper<T> {
+        private List<T> value;
+
+        // Required for JAXB
+
+        @SuppressWarnings({"UnusedDeclaration"})
+        public ListWrapper() {
+        }
+
+        public ListWrapper(List<T> list) {
+            this.value = list;
+        }
+
+        public List<T> getValue() {
+            return value;
+        }
+    }
+}
+

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PatientIdBasedStoredQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PatientIdBasedStoredQuery.java
@@ -17,16 +17,27 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
 import java.io.Serializable;
 
 /**
  * Base class for stored queries by patient ID.
  * @author Dmytro Rud
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PatientIdBasedStoredQuery", propOrder = { "patientId" })
 abstract public class PatientIdBasedStoredQuery extends StoredQuery implements Serializable {
     private static final long serialVersionUID = 8640351939561728468L;
 
     private Identifiable patientId;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public PatientIdBasedStoredQuery() {
+    }
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Query.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Query.java
@@ -17,16 +17,25 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import static org.apache.commons.lang.Validate.notNull;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 /**
  * Base class for all query requests.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Query")
 public abstract class Query implements Serializable {
     private static final long serialVersionUID = 7597105342752455732L;
-    
-    private final QueryType type;
+    @XmlAttribute
+    private QueryType type;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public Query() {
+    }
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryList.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryList.java
@@ -17,9 +17,12 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import static org.apache.commons.lang.Validate.noNullElements;
 import static org.apache.commons.lang.Validate.notNull;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,7 +33,7 @@ import java.util.List;
  * <p>
  * The list allows AND and OR semantics via two levels of lists.
  * The inner lists of parameters have OR semantics. The outer list
- * contains the inner lists and uses AND semantics. E.g. the query 
+ * contains the inner lists and uses AND semantics. E.g. the query
  * list <code>(a, b), (c, d)</code> contains two inner lists and the
  * parameters are evaluated (a OR b) AND (c OR d).
  * @param <T>
@@ -38,16 +41,19 @@ import java.util.List;
  *
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "QueryList")
 public class QueryList<T> implements Serializable {
     private static final long serialVersionUID = -2729640243221349924L;
     
-    private final List<List<T>> outerList = new ArrayList<List<T>>();
-    
+    @XmlJavaTypeAdapter(ListOfListAdapter.class)
+    private List<List<T>> outerList = new ArrayList<List<T>>();
+
     /**
      * Constructs a query list.
      */
     public QueryList() {}
-    
+
     /**
      * Constructs a query list using another list.
      * <p>
@@ -59,11 +65,11 @@ public class QueryList<T> implements Serializable {
         notNull(other, "other cannot be null");
         noNullElements(other.getOuterList(), "other.getOuterList() cannot contain null elements");
         for (List<T> innerList : other.getOuterList()) {
-            noNullElements(innerList, "innerList cannot contain null elements");            
+            noNullElements(innerList, "innerList cannot contain null elements");
             outerList.add(new ArrayList<T>(innerList));
         }
     }
-    
+
     /**
      * Constructs a query list.
      * @param singleElement

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryType.java
@@ -15,39 +15,45 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * All possible query types.
  * @author Jens Riemschneider
  */
+@XmlType(name = "QueryType")
+@XmlEnum(String.class)
 public enum QueryType {
     /** Runs a SQL query. */
-    SQL("sql", SqlQuery.class),
+    @XmlEnumValue("Sql") SQL("sql", SqlQuery.class),
     /** Searches for documents. */
-    FIND_DOCUMENTS("urn:uuid:14d4debf-8f97-4251-9a74-a90016b0af0d", FindDocumentsQuery.class),
+    @XmlEnumValue("FindDocuments") FIND_DOCUMENTS("urn:uuid:14d4debf-8f97-4251-9a74-a90016b0af0d", FindDocumentsQuery.class),
     /** Searches for submission sets. */
-    FIND_SUBMISSION_SETS("urn:uuid:f26abbcb-ac74-4422-8a30-edb644bbc1a9", FindSubmissionSetsQuery.class),
+    @XmlEnumValue("FindSubmissionSets") FIND_SUBMISSION_SETS("urn:uuid:f26abbcb-ac74-4422-8a30-edb644bbc1a9", FindSubmissionSetsQuery.class),
     /** Searches for folders. */
-    FIND_FOLDERS("urn:uuid:958f3006-baad-4929-a4de-ff1114824431", FindFoldersQuery.class),
+    @XmlEnumValue("FindFolders") FIND_FOLDERS("urn:uuid:958f3006-baad-4929-a4de-ff1114824431", FindFoldersQuery.class),
     /** Returns everything. */
-    GET_ALL("urn:uuid:10b545ea-725c-446d-9b95-8aeb444eddf3", GetAllQuery.class),
+    @XmlEnumValue("GetAll") GET_ALL("urn:uuid:10b545ea-725c-446d-9b95-8aeb444eddf3", GetAllQuery.class),
     /** Returns specific documents. */
-    GET_DOCUMENTS("urn:uuid:5c4f972b-d56b-40ac-a5fc-c8ca9b40b9d4", GetDocumentsQuery.class),
+    @XmlEnumValue("GetDocuments") GET_DOCUMENTS("urn:uuid:5c4f972b-d56b-40ac-a5fc-c8ca9b40b9d4", GetDocumentsQuery.class),
     /** Returns specific folders. */
-    GET_FOLDERS("urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4", GetFoldersQuery.class),
+    @XmlEnumValue("GetFolders") GET_FOLDERS("urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4", GetFoldersQuery.class),
     /** Returns specific associations. */
-    GET_ASSOCIATIONS("urn:uuid:a7ae438b-4bc2-4642-93e9-be891f7bb155", GetAssociationsQuery.class),
+    @XmlEnumValue("GetAssociations") GET_ASSOCIATIONS("urn:uuid:a7ae438b-4bc2-4642-93e9-be891f7bb155", GetAssociationsQuery.class),
     /** Returns specific documents and their associations. */
-    GET_DOCUMENTS_AND_ASSOCIATIONS("urn:uuid:bab9529a-4a10-40b3-a01f-f68a615d247a", GetDocumentsAndAssociationsQuery.class),
+    @XmlEnumValue("GetDocumentsAndAssociations") GET_DOCUMENTS_AND_ASSOCIATIONS("urn:uuid:bab9529a-4a10-40b3-a01f-f68a615d247a", GetDocumentsAndAssociationsQuery.class),
     /** Returns specific submission sets. */
-    GET_SUBMISSION_SETS("urn:uuid:51224314-5390-4169-9b91-b1980040715a", GetSubmissionSetsQuery.class),
+    @XmlEnumValue("GetSubmissionSets") GET_SUBMISSION_SETS("urn:uuid:51224314-5390-4169-9b91-b1980040715a", GetSubmissionSetsQuery.class),
     /** Returns specific submission sets and their contents. */
-    GET_SUBMISSION_SET_AND_CONTENTS("urn:uuid:e8e3cb2c-e39c-46b9-99e4-c12f57260b83", GetSubmissionSetAndContentsQuery.class),
+    @XmlEnumValue("GetSubmissionSetAndContents") GET_SUBMISSION_SET_AND_CONTENTS("urn:uuid:e8e3cb2c-e39c-46b9-99e4-c12f57260b83", GetSubmissionSetAndContentsQuery.class),
     /** Returns specific folders and their contents. */
-    GET_FOLDER_AND_CONTENTS("urn:uuid:b909a503-523d-4517-8acf-8e5834dfc4c7", GetFolderAndContentsQuery.class),
+    @XmlEnumValue("GetFolderAndContents") GET_FOLDER_AND_CONTENTS("urn:uuid:b909a503-523d-4517-8acf-8e5834dfc4c7", GetFolderAndContentsQuery.class),
     /** Returns folders for a specific document. */
-    GET_FOLDERS_FOR_DOCUMENT("urn:uuid:10cae35a-c7f9-4cf5-b61e-fc3278ffb578", GetFoldersForDocumentQuery.class),
+    @XmlEnumValue("GetFoldersForDocument") GET_FOLDERS_FOR_DOCUMENT("urn:uuid:10cae35a-c7f9-4cf5-b61e-fc3278ffb578", GetFoldersForDocumentQuery.class),
     /** Returns all documents with a given relation to a specified entry. */
-    GET_RELATED_DOCUMENTS("urn:uuid:d90e5407-b356-4d91-a89f-873917b4b0e6", GetRelatedDocumentsQuery.class);
+    @XmlEnumValue("GetRelatedDocuments") GET_RELATED_DOCUMENTS("urn:uuid:d90e5407-b356-4d91-a89f-873917b4b0e6", GetRelatedDocumentsQuery.class);
     
     private final String id;
     private final Class<? extends Query> type; 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/SqlQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/SqlQuery.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -26,9 +27,12 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SQLQuery")
+@XmlRootElement(name = "sqlQuery")
 public class SqlQuery extends Query implements Serializable {
     private static final long serialVersionUID = -4059622155305044092L;
-    
+
     private String sql;
 
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/StoredQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/StoredQuery.java
@@ -18,16 +18,27 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
 import java.io.Serializable;
 
 /**
  * Base class for stored queries.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "StoredQuery", propOrder = { "homeCommunityId" })
 public abstract class StoredQuery extends Query implements Serializable {
     private static final long serialVersionUID = -8296981156625412818L;
 
     private String homeCommunityId;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public StoredQuery() {
+    }
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/package-info.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@XmlSchema(
+        namespace = "http://www.openehealth.org/ipf/xds",
+        elementFormDefault = XmlNsForm.UNQUALIFIED,
+        attributeFormDefault = XmlNsForm.UNQUALIFIED,
+        xmlns = {
+                @XmlNs(prefix = "xds", namespaceURI = "http://www.openehealth.org/ipf/xds")})
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/ErrorCode.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/ErrorCode.java
@@ -15,88 +15,93 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 /**
  * Error codes specified by the XDS specification.
  * @author Jens Riemschneider
  */
+@XmlType(name = "ErrorCode")
+@XmlEnum(String.class)
 public enum ErrorCode {
     /** Document entry exists in metadata with no corresponding attached document. */
-    MISSING_DOCUMENT("XDSMissingDocument"),
+    @XmlEnumValue("XDSMissingDocument") MISSING_DOCUMENT("XDSMissingDocument"),
     /** MIME package contains MIME part with content-id header not found in metadata. */
-    MISSING_DOCUMENT_METADATA("XDSMissingDocumentMetadata"),
+    @XmlEnumValue("XDSMissingDocumentMetadata") MISSING_DOCUMENT_METADATA("XDSMissingDocumentMetadata"),
     /** Repository was unable to access the registry. */
-    REGISTRY_NOT_AVAILABLE("XDSRegistryNotAvailable"),
+    @XmlEnumValue("XDSRegistryNotAvailable") REGISTRY_NOT_AVAILABLE("XDSRegistryNotAvailable"),
     /** Internal error in registry. */
-    REGISTRY_ERROR("XDSRegistryError"),
+    @XmlEnumValue("XDSRegistryError") REGISTRY_ERROR("XDSRegistryError"),
     /** Internal error in repository. */
-    REPOSITORY_ERROR("XDSRepositoryError"),
+    @XmlEnumValue("XDSRepositoryError") REPOSITORY_ERROR("XDSRepositoryError"),
     /** The registry found a unique ID value that was used more than once within the submission. 
      *  The Code Context indicates the duplicate unique ID. */
-    REGISTRY_DUPLICATE_UNIQUE_ID_IN_MESSAGE("XDSRegistryDuplicateUniqueIdInMessage"),
+    @XmlEnumValue("XDSRegistryDuplicateUniqueIdInMessage") REGISTRY_DUPLICATE_UNIQUE_ID_IN_MESSAGE("XDSRegistryDuplicateUniqueIdInMessage"),
     /** The repository found a unique ID value that was used more than once within the submission. 
      *  The Code Context indicates the duplicate unique ID. */
-    REPOSITORY_DUPLICATE_UNIQUE_ID_IN_MESSAGE("XDSRepositoryDuplicateUniqueIdInMessage"),
+    @XmlEnumValue("XDSRepositoryDuplicateUniqueIdInMessage") REPOSITORY_DUPLICATE_UNIQUE_ID_IN_MESSAGE("XDSRepositoryDuplicateUniqueIdInMessage"),
     /** A unique ID received for a submission set or folder was not unique within the registry. 
      *  The code context indicates the value of the non-unique ID and if it was a folder or submission set. 
      *  Never returned for a document entry. */
-    DUPLICATE_UNIQUE_ID_IN_REGISTRY("XDSDuplicateUniqueIdInRegistry"),
+    @XmlEnumValue("XDSDuplicateUniqueIdInRegistry") DUPLICATE_UNIQUE_ID_IN_REGISTRY("XDSDuplicateUniqueIdInRegistry"),
     /** Document being registered was a duplicate (unique ID already in registry) but the hash codes 
      *  do not match. The code context indicates the unique ID. */
-    NON_IDENTICAL_HASH("XDSNonIdenticalHash"),
+    @XmlEnumValue("XDSNonIdenticalHash") NON_IDENTICAL_HASH("XDSNonIdenticalHash"),
     /** Too much activity in the registry to process the request. */
-    REGISTRY_BUSY("XDSRegistryBusy"),
+    @XmlEnumValue("XDSRegistryBusy") REGISTRY_BUSY("XDSRegistryBusy"),
     /** Too much activity in the repository to process the request. */
-    REPOSITORY_BUSY("XDSRepositoryBusy"),
+    @XmlEnumValue("XDSRepositoryBusy") REPOSITORY_BUSY("XDSRepositoryBusy"),
     /** Resources are too low within the registry to process the request. */
-    REGISTRY_OUT_OF_RESOURCES("XDSRegistryOutOfResources"),
+    @XmlEnumValue("XDSRegistryOutOfResources") REGISTRY_OUT_OF_RESOURCES("XDSRegistryOutOfResources"),
     /** Resources are too low within the repository to process the request. */
-    REPOSITORY_OUT_OF_RESOURCES("XDSRepositoryOutOfResources"),
+    @XmlEnumValue("XDSRepositoryOutOfResources") REPOSITORY_OUT_OF_RESOURCES("XDSRepositoryOutOfResources"),
     /** The registry detected an error in the meta data. The actor name indicates where  
      *  error detected. The code context indicates the nature of the problem. */
-    REGISTRY_METADATA_ERROR("XDSRegistryMetadataError"),
+    @XmlEnumValue("XDSRegistryMetadataError") REGISTRY_METADATA_ERROR("XDSRegistryMetadataError"),
     /** The repository detected an error in the meta data. The actor name indicates where  
      *  error detected. The code context indicates the nature of the problem. */
-    REPOSITORY_METADATA_ERROR("XDSRepositoryMetadataError"),
+    @XmlEnumValue("XDSRepositoryMetadataError") REPOSITORY_METADATA_ERROR("XDSRepositoryMetadataError"),
     /** A request produced too many results to finish the request. */
-    TOO_MANY_RESULTS("XDSTooManyResults"),
+    @XmlEnumValue("XDSTooManyResults") TOO_MANY_RESULTS("XDSTooManyResults"),
     /** Warning returned if extra meta data was present but not saved in the registry. */
-    EXTRA_METADATA_NOT_SAVED("XDSExtraMetadataNotSaved"),
+    @XmlEnumValue("XDSExtraMetadataNotSaved") EXTRA_METADATA_NO_SAVED("XDSExtraMetadataNotSaved"),
     /** The patient ID referenced in the meta data is not known to the registry actor 
      *  via the Patient Identity Feed or is unknown because of patient identifier merge 
      *  or other reasons. The code context includes the value of the problematic patient ID. */
-    UNKNOWN_PATIENT_ID("XDSUnknownPatientId"),
+    @XmlEnumValue("XDSUnknownPatientId") UNKNOWN_PATIENT_ID("XDSUnknownPatientId"),
     /** A patient ID that is required to be identical in the document entries, folders and 
      *  submission sets contained in the request did not match. The code context indicates
      *  the value of the patient ID and the nature of the conflict. */
-    PATIENT_ID_DOES_NOT_MATCH("XDSPatientIdDoesNotMatch"),
+    @XmlEnumValue("XDSPatientIdDoesNotMatch") PATIENT_ID_DOES_NOT_MATCH("XDSPatientIdDoesNotMatch"),
     /** The query ID provided in the request is not recognized. */
-    UNKNOWN_STORED_QUERY("XDSUnknownStoredQuery"),
+    @XmlEnumValue("XDSUnknownStoredQuery") UNKNOWN_STORED_QUERY("XDSUnknownStoredQuery"),
     /** A required parameter to a stored query is missing. */
-    STORED_QUERY_MISSING_PARAM("XDSStoredQueryMissingParam"),
+    @XmlEnumValue("XDSStoredQueryMissingParam") STORED_QUERY_MISSING_PARAM("XDSStoredQueryMissingParam"),
     /** A parameter which only accepts a single value is coded with multiple values. */
-    STORED_QUERY_PARAM_NUMBER("XDSStoredQueryParamNumber"),
+    @XmlEnumValue("XDSStoredQueryParamNumber") STORED_QUERY_PARAM_NUMBER("XDSStoredQueryParamNumber"),
     /** An error occurred when executing an SQL query. */
-    SQL_ERROR("XDSSqlError"),
+    @XmlEnumValue("XDSSqlError") SQL_ERROR("XDSSqlError"),
     /** A register transaction was rejected because it submitted an association referencing 
      *  a deprecated document. */
-    REGISTRY_DEPRECATED_DOCUMENT_ERROR("XDSRegistryDeprecatedDocumentError"),
-    /** The document associated with the DocumentUniqueId is not available. */
-    DOCUMENT_UNIQUE_ID_ERROR("XDSDocumentUniqueIdError"),
-    /** The unique ID of a repository could not be resolved to a valid document repository
+    @XmlEnumValue("XDSRegistryDeprecatedDocumentError") REGISTRY_DEPRECATED_DOCUMENT_ERROR("XDSRegistryDeprecatedDocumentError"),
+    /** The document associated with the DocumentUniqueId is not available.*/
+    @XmlEnumValue("XDSDocumentUniqueIdError") DOCUMENT_UNIQUE_ID_ERROR("XDSDocumentUniqueIdError"),
+    /** The unique ID of a repository could not be resolved to a valid document repository 
      *  or the value does not match that of the document repository. */
-    UNKNOWN_REPOSITORY_ID("XDSUnknownRepositoryId"),
+    @XmlEnumValue("XDSUnknownRepositoryId") UNKNOWN_REPOSITORY_ID("XDSUnknownRepositoryId"),
     /** A query resulted in returning information about multiple patients, which is forbidden
      *  because of security reasons. */ 
-    RESULT_NOT_SINGLE_PATIENT("XDSResultNotSinglePatient"),
+    @XmlEnumValue("XDSResultNotSinglePatient") RESULT_NOT_SINGLE_PATIENT("XDSResultNotSinglePatient"),
 
     /* Some additional error codes from XCA, dealing with homeCommunityIDs */
     
     /** A value for the homeCommunityId is not recognized */
-    UNKNOWN_COMMUNITY("XDSUnknownCommunity"),
+    @XmlEnumValue("XDSUnknownCommunity") UNKNOWN_COMMUNITY("XDSUnknownCommunity"),
     /** A value for the homeCommunityId is required and has not been specified */
-    MISSING_HOME_COMMUNITY_ID("XDSMissingHomeCommunityId"),
+    @XmlEnumValue("XDSMissingHomeCommunityId") MISSING_HOME_COMMUNITY_ID("XDSMissingHomeCommunityId"),
     /** A community which would have been contacted was not available */
-    UNAVAILABLE_COMMUNITY("XDSUnavailableCommunity");
+    @XmlEnumValue("XDSUnavailableCommunity") UNAVAILABLE_COMMUNITY("XDSUnavailableCommunity");
     
     private final String opcode;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/ErrorInfo.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/ErrorInfo.java
@@ -15,6 +15,9 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
 import java.io.Serializable;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -27,6 +30,8 @@ import org.openehealth.ipf.commons.ihe.xds.core.validate.XDSMetaDataException;
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ErrorInfo", propOrder = {"errorCode", "codeContext", "severity", "location"})
 public class ErrorInfo implements Serializable {
     private static final long serialVersionUID = 7615868122051414551L;
     

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/QueryResponse.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/QueryResponse.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,13 +34,22 @@ import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
  * Lists are pre-created and can therefore never be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "QueryResponse", propOrder = {
+        "references", "submissionSets", "folders", "documentEntries", "associations"})
+@XmlRootElement(name = "queryResponse")
 public class QueryResponse extends Response implements Serializable {
     private static final long serialVersionUID = -435462523350768903L;
     
+    @XmlElement(name = "reference")
     private List<ObjectReference> references = new ArrayList<ObjectReference>();
+    @XmlElementRef
     private List<DocumentEntry> documentEntries = new ArrayList<DocumentEntry>();
+    @XmlElementRef
     private List<Folder> folders = new ArrayList<Folder>();
+    @XmlElementRef
     private List<SubmissionSet> submissionSets = new ArrayList<SubmissionSet>();
+    @XmlElementRef
     private List<Association> associations = new ArrayList<Association>();
     
     /**
@@ -55,7 +65,7 @@ public class QueryResponse extends Response implements Serializable {
     public QueryResponse(Status status) {        
         super(status);
     }
-
+    
     /**
      * Constructs an error response object with the data from an exception.
      * @param throwable

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/Response.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/Response.java
@@ -15,14 +15,13 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
-
-import org.openehealth.ipf.commons.ihe.xds.core.validate.XDSMetaDataException;
 
 /**
  * Basic response information.
@@ -31,10 +30,14 @@ import org.openehealth.ipf.commons.ihe.xds.core.validate.XDSMetaDataException;
  * The lists are pre-created and can therefore never be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Response", propOrder = {"status", "errors"})
+@XmlRootElement(name = "response")
 public class Response implements Serializable {
     private static final long serialVersionUID = -6370795461214680771L;
     
     private Status status;
+    @XmlElement(name = "error")
     private List<ErrorInfo> errors = new ArrayList<ErrorInfo>();
     
     /**
@@ -50,7 +53,7 @@ public class Response implements Serializable {
     public Response(Status status) {        
         this.status = status;
     }
-
+    
     /**
      * Constructs an error response object with the data from an exception.
      * @param throwable

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/RetrievedDocument.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/RetrievedDocument.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 
 import javax.activation.DataHandler;
@@ -29,10 +30,14 @@ import org.openehealth.ipf.commons.ihe.xds.core.requests.RetrieveDocument;
  * All members of this class are allowed to be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "RetrievedDocument")
+@XmlRootElement(name = "retrievedDocument")
 public class RetrievedDocument implements Serializable {
     private static final long serialVersionUID = -3950026651885804263L;
     
     private transient DataHandler dataHandler;
+    @XmlElementRef
     private RetrieveDocument requestData;
     
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/RetrievedDocumentSet.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/RetrievedDocumentSet.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
+import javax.xml.bind.annotation.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +29,13 @@ import org.apache.commons.lang.builder.ToStringStyle;
  * Lists are pre-created and can therefore never be <code>null</code>.
  * @author Jens Riemschneider
  */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "RetrievedDocumentSet")
+@XmlRootElement(name = "retrievedDocumentSet")
 public class RetrievedDocumentSet extends Response implements Serializable {    
     private static final long serialVersionUID = 4389321453383292730L;
     
+    @XmlElementRef
     private final List<RetrievedDocument> documents = new ArrayList<RetrievedDocument>();
 
     /**
@@ -58,7 +63,7 @@ public class RetrievedDocumentSet extends Response implements Serializable {
         super(status);
         this.documents.addAll(documents);
     }
-
+    
     /**
      * Constructs an error response object with the data from an exception.
      * @param throwable

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/Severity.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/Severity.java
@@ -17,15 +17,20 @@ package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
 import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs21.rs.ErrorType;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 /**
  * Severities defined by the XDS specification.
  * @author Jens Riemschneider
  */
+@XmlType(name = "Severity")
+@XmlEnum(String.class)
 public enum Severity {
     /** An error. */
-    ERROR(ErrorType.ERROR, "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error"),
+    @XmlEnumValue("Error") ERROR(ErrorType.ERROR, "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error"),
     /** A warning. */
-    WARNING(ErrorType.WARNING, "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning");
+    @XmlEnumValue("Warning") WARNING(ErrorType.WARNING, "urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Warning");
     
     private final ErrorType ebXML21;
     private final String opcode30;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/Status.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/Status.java
@@ -15,17 +15,22 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.responses;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 /**
  * Status information according to the XDS specification.
  * @author Jens Riemschneider
  */
+@XmlType(name = "Status")
+@XmlEnum(String.class)
 public enum Status {
     /** The request execution failed. */
-    FAILURE("Failure", "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure"),
+    @XmlEnumValue("Failure") FAILURE("Failure", "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure"),
     /** The request execution succeeded. */
-    SUCCESS("Success", "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"),
+    @XmlEnumValue("Success") SUCCESS("Success", "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"),
     /** The request execution partially succeeded. */
-    PARTIAL_SUCCESS("PartialSuccess", "urn:ihe:iti:2007:ResponseStatusType:PartialSuccess");
+    @XmlEnumValue("PartialSuccess") PARTIAL_SUCCESS("PartialSuccess", "urn:ihe:iti:2007:ResponseStatusType:PartialSuccess");
     
     private final String opcode21;
     private final String opcode30;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/package-info.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/responses/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@XmlSchema(
+        namespace = "http://www.openehealth.org/ipf/xds",
+        elementFormDefault = XmlNsForm.UNQUALIFIED,
+        attributeFormDefault = XmlNsForm.UNQUALIFIED,
+        xmlns = {
+                @XmlNs(prefix = "xds", namespaceURI = "http://www.openehealth.org/ipf/xds")})
+package org.openehealth.ipf.commons.ihe.xds.core.responses;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/TimeRangeTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/TimeRangeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.metadata;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Node;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import javax.xml.transform.dom.DOMResult;
+
+public class TimeRangeTest {
+    @Test
+    public void testXmlDateSerialization() throws Exception {
+        TimeRange timeRange = new TimeRange();
+
+        timeRange.setFrom("2011030512");
+        timeRange.setTo("20120301080642.190");
+        checkSerialization("timeRange", timeRange);
+
+        timeRange.setFrom("20110305");
+        timeRange.setTo("2012");
+        checkSerialization("timeRange", timeRange);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private <T> void checkSerialization(String name, T object) throws Exception {
+        QName qname = new QName("http://www.openehealth.org/ipf/xds", name);
+        JAXBElement<T> jaxbElement = new JAXBElement<T>(qname, (Class<T>) object.getClass(), object);
+        JAXBContext jaxbContext = JAXBContext.newInstance(TimeRange.class);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        marshaller.marshal(jaxbElement, System.out);
+
+        DOMResult domResult = new DOMResult();
+        marshaller.marshal(jaxbElement, domResult);
+        Node marshalledNode = ((org.w3c.dom.Document) domResult.getNode()).getDocumentElement();
+
+        Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+        jaxbElement = (JAXBElement<T>) unmarshaller.unmarshal(marshalledNode, TimeRange.class);
+        T objectToo = jaxbElement.getValue();
+
+        Assert.assertEquals(object, objectToo);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryListTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryListTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.w3c.dom.Node;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import javax.xml.transform.dom.DOMResult;
+import java.util.Arrays;
+import java.util.List;
+
+public class QueryListTest {
+    @Test
+    public void testXmlSerializationWithString() throws Exception {
+        List<String> innerList1 = Arrays.asList("Lisa", "Jodi", "Terry", "Cassandra");
+        List<String> innerList2 = Arrays.asList("Brock", "Thor", "Venus");
+
+        QueryList<String> queryList = new QueryList<String>();
+        queryList.getOuterList().add(innerList1);
+        queryList.getOuterList().add(innerList2);
+
+        JAXBContext jaxbContext = JAXBContext.newInstance(QueryList.class);
+        checkSerialization(jaxbContext, "queryList", queryList);
+    }
+
+    @Test
+    public void testXmlSerializationWithCode() throws Exception {
+        List<Code> innerList1 = Arrays.asList(
+                new Code("Lisa", null, "Girlfriend scheme"),
+                new Code("Jodi", null, "Girlfriend scheme"),
+                new Code("Terry", null, "Girlfriend scheme"),
+                new Code("Cassandra", null, "Girlfriend scheme"));
+        List<Code> innerList2 = Arrays.asList(
+                new Code("Brock", null, "Children scheme"),
+                new Code("Thor", null, "Children scheme"),
+                new Code("Venus", null, "Children scheme"));
+
+        QueryList<Code> queryList = new QueryList<Code>();
+        queryList.getOuterList().add(innerList1);
+        queryList.getOuterList().add(innerList2);
+
+        JAXBContext jaxbContext = JAXBContext.newInstance(QueryList.class, Code.class);
+        checkSerialization(jaxbContext, "queryList", queryList);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private <T> void checkSerialization(JAXBContext jaxbContext, String name, T object) throws Exception {
+        QName qname = new QName("http://www.openehealth.org/ipf/xds", name);
+        JAXBElement<T> jaxbElement = new JAXBElement<T>(qname, (Class<T>) object.getClass(), object);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        marshaller.marshal(jaxbElement, System.out);
+
+        DOMResult domResult = new DOMResult();
+        marshaller.marshal(jaxbElement, domResult);
+        Node marshalledNode = ((org.w3c.dom.Document) domResult.getNode()).getDocumentElement();
+
+        Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+        jaxbElement = (JAXBElement<T>) unmarshaller.unmarshal(marshalledNode, QueryList.class);
+        T objectToo = jaxbElement.getValue();
+
+        Assert.assertEquals(object, objectToo);
+    }
+}


### PR DESCRIPTION
Added JAXB annotations and related adapters for serializing the XDS simplified model classes into XML or JSON
