### PR TITLE
Provider management naming strategy to show categorized processors tree

### DIFF
--- a/platform-camel/core/src/main/java/org/openehealth/ipf/platform/camel/core/management/ProcessorManagementNamingStrategy.java
+++ b/platform-camel/core/src/main/java/org/openehealth/ipf/platform/camel/core/management/ProcessorManagementNamingStrategy.java
@@ -1,0 +1,37 @@
+package org.openehealth.ipf.platform.camel.core.management;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Processor;
+import org.apache.camel.management.DefaultManagementNamingStrategy;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.ProcessorDefinitionHelper;
+import org.apache.camel.model.RouteDefinition;
+
+public class ProcessorManagementNamingStrategy extends
+		DefaultManagementNamingStrategy {
+
+	public static final String KEY_ROUTE = "route";
+
+	public ObjectName getObjectNameForProcessor(CamelContext context,
+			Processor processor, ProcessorDefinition<?> definition)
+			throws MalformedObjectNameException {
+
+		StringBuilder buffer = new StringBuilder();
+		buffer.append(domainName).append(":");
+		buffer.append(KEY_CONTEXT + "=").append(getContextId(context)).append(",");
+		buffer.append(KEY_TYPE + "=").append(TYPE_PROCESSOR).append(",");
+
+		RouteDefinition route = ProcessorDefinitionHelper.getRoute(definition);
+
+		if (route != null) {
+			buffer.append(KEY_ROUTE + "=").append(route.getId()).append(",");
+		}
+
+		buffer.append(KEY_NAME + "=").append(ObjectName.quote(definition.getId()));
+		return createObjectName(buffer);
+	}
+
+}

--- a/platform-camel/core/src/test/java/org/openehealth/ipf/platform/camel/core/management/ManagementNamingStrategyTestRouteBuilder.java
+++ b/platform-camel/core/src/test/java/org/openehealth/ipf/platform/camel/core/management/ManagementNamingStrategyTestRouteBuilder.java
@@ -1,0 +1,27 @@
+package org.openehealth.ipf.platform.camel.core.management;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.spring.SpringRouteBuilder;
+
+public class ManagementNamingStrategyTestRouteBuilder extends
+		SpringRouteBuilder {
+
+	@Override
+	public void configure() throws Exception {
+
+		from("direct:input")
+			.routeId("namingStrategyRoute")
+			.process(
+				new Processor() {
+
+					@Override
+					public void process(Exchange exchange) throws Exception {
+
+					}
+				})
+			.id("namingStrategyProcessor")
+			.end();
+	}
+
+}

--- a/platform-camel/core/src/test/java/org/openehealth/ipf/platform/camel/core/management/ProcessorManagementNamingStrategyTest.java
+++ b/platform-camel/core/src/test/java/org/openehealth/ipf/platform/camel/core/management/ProcessorManagementNamingStrategyTest.java
@@ -1,0 +1,58 @@
+package org.openehealth.ipf.platform.camel.core.management;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Set;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+
+import org.apache.camel.CamelContext;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class ProcessorManagementNamingStrategyTest {
+
+	private static final String CONTEXT = "context-core-management.xml";
+
+	private static CamelContext camelContext;
+
+	private static ClassPathXmlApplicationContext appContext;
+
+	@BeforeClass
+	public static void setUpContext() {
+
+		appContext = new ClassPathXmlApplicationContext(CONTEXT);
+		camelContext = appContext.getBean("camelContext", CamelContext.class);
+	}
+
+	@Test
+	public void testProcessorManagementNamingStrategy() throws Exception {
+
+		ObjectName on = queryForNamedObjects("org.apache.camel:context=*/camelContext,type=processors,route=namingStrategyRoute,name=\"namingStrategyProcessor\"");
+
+		ObjectInstance oi = getMBeanServer().getObjectInstance(on);
+		assertNotNull(oi);
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() {
+
+		appContext.destroy();
+	}
+
+	private ObjectName queryForNamedObjects(String query) throws Exception {
+
+		MBeanServer mbeanServer = getMBeanServer();
+		Set<ObjectName> s = mbeanServer.queryNames(new ObjectName(query), null);
+		return (ObjectName) s.toArray()[0];
+	}
+
+	private MBeanServer getMBeanServer() {
+
+		return camelContext.getManagementStrategy().getManagementAgent().getMBeanServer();
+	}
+}

--- a/platform-camel/core/src/test/resources/context-core-management.xml
+++ b/platform-camel/core/src/test/resources/context-core-management.xml
@@ -1,0 +1,26 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:lang="http://www.springframework.org/schema/lang"
+	xmlns:camel="http://camel.apache.org/schema/spring" xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="
+http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans.xsd
+http://www.springframework.org/schema/lang
+http://www.springframework.org/schema/lang/spring-lang.xsd
+http://www.springframework.org/schema/util
+http://www.springframework.org/schema/util/spring-util.xsd
+http://camel.apache.org/schema/spring 
+http://camel.apache.org/schema/spring/camel-spring.xsd 
+">
+
+	<camel:camelContext id="camelContext">
+		<camel:jmxAgent id="agent" disabled="false" />
+		<camel:routeBuilder ref="routeBuilder" />
+	</camel:camelContext>
+
+	<bean id="routeBuilder"
+		class="org.openehealth.ipf.platform.camel.core.management.ManagementNamingStrategyTestRouteBuilder" />
+
+	<bean id="processorNaming"
+		class="org.openehealth.ipf.platform.camel.core.management.ProcessorManagementNamingStrategy" />
+
+</beans>


### PR DESCRIPTION
provided ProcessorManagementNamingStrategy to have route nodes added to the treeview in jconsole, this is to cover JIRA ESB-474
thanks
Reinhard
