### PR TITLE
Requesting XmlAdapter for Name core.metadata class.

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/IHENameAdapter.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/IHENameAdapter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.metadata;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * A JAXB {@link XmlAdapter} that allows the Name class to be serialized.
+ * <p/>
+ * The original implementation of the {@link Name} class was concrete and had no subclasses. The XML serialization of
+ * a {@link Name} used to look like this:
+ * <pre>
+ * {@code
+ *
+ * <name>
+ *    <given>John</given>
+ *    <family>Doe</family>
+ * </name>
+ *     }
+ * </pre>
+ * <p/>
+ * When the {@link Name} class was made abstract, the xml above could no longer be serialized. This adapter allows
+ * the XML shown above to be serialized without change.
+ * @author Michael Ottati
+ */
+public class IHENameAdapter extends XmlAdapter<XpnName,Name> {
+    @Override
+    public Name unmarshal(XpnName v) throws Exception {
+        return v;
+    }
+
+    @Override
+    public XpnName marshal(Name v) throws Exception {
+
+        return new XpnName( v.getFamilyName(),
+                            v.getGivenName(),
+                            v.getSecondAndFurtherGivenNames(),
+                            v.getSuffix(),
+                            v.getPrefix(),
+                            v.getDegree()
+        );
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Name.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/metadata/Name.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * This class represents a name.
@@ -37,6 +38,7 @@ import javax.xml.bind.annotation.XmlType;
  * @author Dmytro Rud
  */
 @XmlAccessorType(XmlAccessType.PUBLIC_MEMBER)
+@XmlJavaTypeAdapter(value = IHENameAdapter.class)
 @XmlType(name = "Name", propOrder = {"prefix", "givenName", "secondAndFurtherGivenNames",
         "familyName", "suffix", "degree"})
 abstract public class Name<T extends Composite> extends Hl7v2Based<T> {


### PR DESCRIPTION
I am requesting this change so that we can unmarshall data we have stored with the pre 2.4 version of the org.openehealth.ipf.commons.ihe.xds.core.metadata.Name class.

Sorry about the fact that it is showing 2 commits, I am new to git and a bit unclear about how to "squash" (rebase?) these out. I will get better over time on that.
