### PR TITLE
ITI-51 Multi-Patient Query

### DIFF
--- a/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/custom/CustomXdsAuditor.java
+++ b/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/custom/CustomXdsAuditor.java
@@ -92,7 +92,7 @@ public class CustomXdsAuditor extends XDSAuditor {
      * @param homeCommunityId The home community id of the transaction (if present)
      * @param patientId The patient ID queried (if query pertained to a patient id)
      */
-    public void auditRegistryStoredQueryEvent(
+    public void auditRegistryMultiPatientQueryEvent(
             RFC3881EventCodes.RFC3881EventOutcomeCodes eventOutcome,
             String consumerUserId, String consumerUserName, String consumerIpAddress,
             String registryEndpointUri,

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/iti51/Iti51ServerAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/iti51/Iti51ServerAuditStrategy.java
@@ -16,8 +16,6 @@
 package org.openehealth.ipf.commons.ihe.xds.iti51;
 
 import org.openehealth.ipf.commons.ihe.core.atna.AuditorManager;
-import org.openehealth.ipf.commons.ihe.xds.iti51.Iti51AuditDataset;
-import org.openehealth.ipf.commons.ihe.xds.iti51.Iti51AuditStrategy;
 
 /**
  * Server audit strategy for ITI-51.
@@ -47,13 +45,13 @@ public class Iti51ServerAuditStrategy extends Iti51AuditStrategy {
 
     @Override
     public void doAudit(Iti51AuditDataset auditDataset) {
-        AuditorManager.getCustomXdsAuditor().auditRegistryStoredQueryEvent(
+        AuditorManager.getCustomXdsAuditor().auditRegistryMultiPatientQueryEvent(
                 auditDataset.getEventOutcomeCode(),
-                auditDataset.getUserId(), 
+                auditDataset.getUserId(),
                 auditDataset.getUserName(),
-                auditDataset.getClientIpAddress(), 
+                auditDataset.getClientIpAddress(),
                 auditDataset.getServiceEndpointUrl(),
-                auditDataset.getQueryUuid(), 
+                auditDataset.getQueryUuid(),
                 auditDataset.getRequestPayload(),
                 auditDataset.getHomeCommunityId(),
                 auditDataset.getPatientId());

--- a/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/iti51/TestIti51.groovy
+++ b/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/iti51/TestIti51.groovy
@@ -108,7 +108,7 @@ class TestIti51 extends StandardTestContainer {
             assert message.ParticipantObjectIdentification.size() == 2
             assert message.children().size() == 6
             //TODO This test fails because there needs to be a corresponding methods added to
-            // org.openhealthtools.ihe.atna.auditor.XDSConsumerAuditor.auditRegistryStoredQueryEvent
+            // org.openhealthtools.ihe.atna.auditor.XDSConsumerAuditor.auditRegistryMultiPatientQueryEvent
             // and
             // org.openhealthtools.ihe.atna.auditor.codes.ihe.IHETransactionEventTypeCodes.RegistryStoredQuery
             // The methods that need to be added are the MPQ variations of the methods listed above.

--- a/pom.xml
+++ b/pom.xml
@@ -49,15 +49,15 @@
         <resources-plugin-version>2.4.3</resources-plugin-version>
         
         <!-- Dependency version properties -->
-        <activemq-version>5.5.1</activemq-version>
+        <activemq-version>5.6.0</activemq-version>
         <aspectj-version>1.6.2</aspectj-version>
         <camel-version>2.9.2</camel-version>
-        <commons-codec-version>1.5</commons-codec-version>
+        <commons-codec-version>1.6</commons-codec-version>
         <commons-collections-version>3.2.1</commons-collections-version>
         <commons-dbcp-version>1.4</commons-dbcp-version>
         <commons-fileupload-version>1.2.2</commons-fileupload-version>        
         <commons-httpclient-version>3.1</commons-httpclient-version>
-        <commons-io-version>2.3</commons-io-version>
+        <commons-io-version>2.4</commons-io-version>
         <commons-lang-version>3.1</commons-lang-version>
         <commons-logging-version>1.1.1</commons-logging-version>
         <commons-math-version>2.2</commons-math-version>
@@ -82,7 +82,7 @@
         <junit-version>4.10</junit-version>
         <junitperf-version>1.8</junitperf-version>
         <log4j-version>1.2.17</log4j-version>
-        <lombok-version>0.11.0</lombok-version>
+        <lombok-version>0.11.2</lombok-version>
         <mdht-version>0.7.0.201012100720</mdht-version>
         <metabuilder-version>1.1.6</metabuilder-version>
         <mina-version>1.1.7</mina-version>


### PR DESCRIPTION
This pull request contains an implementation of Multi Patient Query (ITI-51)
- Renamed AbstractDocumentsQuery to DocumentsQuery
  The only difference between the stored queries and their MPQ variants is that the MPQ queries  accept a (possibly empty) list of Patient IDs and the stored queries must have exactly 1 patient ID  passed as a string. In order to take advantage of the AbastractDocuments query as a common subclass,  I moved the patient ID accessor for FindDocumentsQuery and FindFoldersQuery into those classes. The MPQ variants are now subclassed off of the DocumentsQuery class.
- Added XmlEnumValues for FindDocumentsForMultiplePatients and FindFoldersForMultiplePatients
- Implemented Transformers for the MPQ queries.
- Implemented Validators for the MPQ queries.

The mpq validatators differ in how they process patientId lists. 
- Implemented Audit messages for the MPQ queries
- Implements Camel endpoints for the MPQ queries.  
- Added new test cases as appropriate cases above.

All existing tests and all new tests pass on this branch. 
